### PR TITLE
Add libx11-dev to the list of packages to install.

### DIFF
--- a/scripts/ubuntu-trusty/Dockerfile
+++ b/scripts/ubuntu-trusty/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:trusty
 MAINTAINER Anil Madhavapeddy <anil@recoil.org>
 ADD opam-installext /usr/bin/opam-installext
 RUN apt-get -y update
-RUN apt-get -y install sudo pkg-config git build-essential m4 software-properties-common aspcud unzip curl
+RUN apt-get -y install sudo pkg-config git build-essential m4 software-properties-common aspcud unzip curl libx11-dev
 ADD scripts/ubuntu-trusty/opam.list /etc/apt/sources.list.d/opam.list
 RUN curl -OL http://download.opensuse.org/repositories/home:ocaml/xUbuntu_14.04/Release.key
 RUN apt-key add - < Release.key


### PR DESCRIPTION
A number of packages are currently failing to build because the [graphics](https://github.com/ocaml/ocaml/tree/trunk/otherlibs/graph) package is missing.  For example:
- [cairo2](https://github.com/ocaml/opam-bulk-logs/blob/2a43f506253b8e09004aa6499957b0b21658cf03/20140906/roo/4.02.0/raw/cairo2#L403) (and [here](https://github.com/ocaml/opam-bulk-logs/blob/2a43f506253b8e09004aa6499957b0b21658cf03/20140906/roo/4.02.0/raw/cairo2#L432))
- [eliom](https://github.com/ocaml/opam-bulk-logs/blob/2a43f506253b8e09004aa6499957b0b21658cf03/20140906/roo/4.02.0/raw/eliom#L8297) (and [here](https://github.com/ocaml/opam-bulk-logs/blob/2a43f506253b8e09004aa6499957b0b21658cf03/20140906/roo/4.02.0/raw/eliom#L8893))
- [litiom](https://github.com/ocaml/opam-bulk-logs/blob/2a43f506253b8e09004aa6499957b0b21658cf03/20140906/roo/4.02.0/raw/litiom#L8306) (and [here](https://github.com/ocaml/opam-bulk-logs/blob/2a43f506253b8e09004aa6499957b0b21658cf03/20140906/roo/4.02.0/raw/litiom#L8903))
- [mesh](https://github.com/ocaml/opam-bulk-logs/blob/2a43f506253b8e09004aa6499957b0b21658cf03/20140906/roo/4.02.0/raw/mesh#L174) (and [here](https://github.com/ocaml/opam-bulk-logs/blob/2a43f506253b8e09004aa6499957b0b21658cf03/20140906/roo/4.02.0/raw/mesh#L203))
- [ocamlviz](https://github.com/ocaml/opam-bulk-logs/blob/2a43f506253b8e09004aa6499957b0b21658cf03/20140906/roo/4.02.0/raw/ocamlviz#L2241) (and [here](https://github.com/ocaml/opam-bulk-logs/blob/2a43f506253b8e09004aa6499957b0b21658cf03/20140906/roo/4.02.0/raw/ocamlviz#L2279))
- [async_graphics](https://github.com/ocaml/opam-bulk-logs/blob/2a43f506253b8e09004aa6499957b0b21658cf03/20140906/roo/4.02.0/raw/async_graphics#L6631) (and [here](https://github.com/ocaml/opam-bulk-logs/blob/2a43f506253b8e09004aa6499957b0b21658cf03/20140906/roo/4.02.0/raw/async_graphics#L6684))

This pull request adds `libx11-dev` to the DockerScript so that the graphics packages builds.
